### PR TITLE
Updates ink to latest version and replaces deprecated components

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"babel-plugin-transform-react-jsx": "^6.24.1",
 		"eslint-config-xo-react": "^0.13.0",
 		"eslint-plugin-react": "^7.1.0",
-		"ink": "^0.2.1",
+		"ink": "^0.5.0",
 		"sinon": "^2.3.6",
 		"xo": "^0.18.2"
 	},

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {h, Text, Component} = require('ink');
+const {h, Color, Component} = require('ink');
 const PropTypes = require('prop-types');
 const hasAnsi = require('has-ansi');
 
@@ -18,9 +18,9 @@ class PasswordInput extends Component {
 		const maskedValue = mask.repeat(value.length);
 
 		return (
-			<Text dim={!hasValue}>
+			<Color dim={!hasValue}>
 				{hasValue ? maskedValue : placeholder}
-			</Text>
+			</Color>
 		);
 	}
 

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 import {spy} from 'sinon';
 import test from 'ava';
-import {h, build, renderToString, render, Text} from 'ink';
+import {h, build, renderToString, render, Color} from 'ink';
 import TextInput from '.';
 
 test('default state', t => {
@@ -17,7 +17,7 @@ test('display value with custom mask', t => {
 });
 
 test('display placeholder', t => {
-	t.is(renderToString(<TextInput placeholder="Placeholder"/>), renderToString(<Text dim>Placeholder</Text>));
+	t.is(renderToString(<TextInput placeholder="Placeholder"/>), renderToString(<Color dim>Placeholder</Color>));
 });
 
 test.serial('attach keypress listener', t => {


### PR DESCRIPTION
Hello good people of ink-password-input,

`<Text/>` component has been deprecated in favour of a more decoupled solution.
See vadimdemedes/ink#65 and vadimdemedes/ink#82